### PR TITLE
Find CPAN Module Counts on search.cpan.org

### DIFF
--- a/db/migrate/20101220190035_fix_cpan_stats.rb
+++ b/db/migrate/20101220190035_fix_cpan_stats.rb
@@ -1,0 +1,15 @@
+class FixCPANStats < ActiveRecord::Migration
+  def self.up
+    r       = Repository.find( :first, :conditions => "name = 'CPAN'" )
+    r.url   = "http://search.cpan.org/"
+    r.regex = "([\\d,]+) Modules"
+    r.update_count
+  end
+
+  def self.down
+    r       = Repository.find( :first, :conditions => "name = 'CPAN'" )
+    r.url   = "http://www.cpan.org/"
+    r.regex = "authors ([\\d,]+) modules"
+    r.update_count
+  end
+end


### PR DESCRIPTION
The Perl module stats on cpan.org represent a fraction of the modules on the CPAN.  search.cpan.org has the full count.

This patch adds a suggested migration to change the data source for Perl modules.
